### PR TITLE
Release/0.0.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,9 +2,9 @@
 * text=auto eol=lf
 
 # prevent composer from downloading these files
-.gitattributes     export-ignore
-.gitignore         export-ignore
-.travis.yml        export-ignore
-phpunit.xml        export-ignore
-tests              export-ignore
-README.md          export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+.travis.yml      export-ignore
+phpunit.xml      export-ignore
+tests/*Test.php  export-ignore
+README.md        export-ignore

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,11 @@
     },
     "autoload": {
         "psr-4": {
-            "jdenoc\\NetworkScanner\\": "src"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
+            "jdenoc\\NetworkScanner\\": "src",
             "jdenoc\\NetworkScanner\\Tests\\": "tests"
         }
+    },
+    "archive": {
+        "exclude": [".git*", "phpunit.xml", ".travis.yml", "*.md", "*Test.php"]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,7 @@
         "name": "jdenoc",
         "email": "jdenoc@gmail.com"
     }],
-    "require": {
-    },
+    "require": {},
     "require-dev": {
         "phpunit/phpunit": "^4.8",
         "fzaninotto/faker": "^1.6"

--- a/src/NetworkScanner.php
+++ b/src/NetworkScanner.php
@@ -45,9 +45,9 @@ class NetworkScanner {
             //192.168.5.1              ether   01:12:3b:44:53:d6   C                     eth0
 
             if(
-                strpos($network_output_line, strtolower($this->normalise_physical_address($physical_address, self::PHYSICAL_ADDRESS_SEPARATOR_COLON))) !== false
-                || strpos($network_output_line, strtolower($this->normalise_physical_address($physical_address, self::PHYSICAL_ADDRESS_SEPARATOR_DASH))) !== false
-                || strpos($network_output_line, strtolower($this->normalise_physical_address($physical_address, self::PHYSICAL_ADDRESS_SEPARATOR_NA))) !== false
+                stripos($network_output_line, $this->normalise_physical_address($physical_address, self::PHYSICAL_ADDRESS_SEPARATOR_COLON)) !== false
+                || stripos($network_output_line, $this->normalise_physical_address($physical_address, self::PHYSICAL_ADDRESS_SEPARATOR_DASH)) !== false
+                || stripos($network_output_line, $this->normalise_physical_address($physical_address, self::PHYSICAL_ADDRESS_SEPARATOR_NA)) !== false
             ){
                 // extract IP address from line
                 $ip_address_match = array();
@@ -112,15 +112,9 @@ class NetworkScanner {
             return '';
         }
 
-        if(strpos($physical_address, self::PHYSICAL_ADDRESS_SEPARATOR_COLON) > 0){
-            $current_separator = self::PHYSICAL_ADDRESS_SEPARATOR_COLON;
-        } elseif(strpos($physical_address, self::PHYSICAL_ADDRESS_SEPARATOR_DASH) > 0){
-            $current_separator = self::PHYSICAL_ADDRESS_SEPARATOR_DASH;
-        } else {
-            $current_separator = self::PHYSICAL_ADDRESS_SEPARATOR_NA;
-        }
-
-        return str_replace($current_separator, $new_separator, $physical_address);
+        $physical_address = preg_replace("/[^A-Fa-f0-9 ]/", '', $physical_address);
+        $split_physical_address = str_split($physical_address, 2);
+        return implode($new_separator, $split_physical_address);
     }
 
     /**

--- a/tests/NetworkScanner.php
+++ b/tests/NetworkScanner.php
@@ -9,6 +9,14 @@ class NetworkScanner extends NetScan {
     private $arp_failure = false;
     private $response_component = array();
 
+    public function __construct(){
+        parent::__construct();
+
+        $this->add_mac_address_to_response('192.168.1.2', '01-23-45-67-89-ab');
+        $this->add_mac_address_to_response('192.168.1.3', 'CD:EF:01:23:45:67');
+        $this->add_mac_address_to_response('192.168.1.4', '89abcdef0123');
+    }
+
     /**
      * @param string $new_system_os
      */
@@ -56,19 +64,18 @@ class NetworkScanner extends NetScan {
         if($this->arp_failure){
             $arp_output = $this->get_empty_arp_output();
         }
-        return explode("\n", $arp_output);
+        return explode(PHP_EOL, $arp_output);
     }
 
     /**
      * @return string
      */
     private function get_example_windows_arp_output(){
-        $arp_output = '';
-        $arp_output .= 'Internet Address      Physical Address      Type';
-        $arp_output .= '192.168.5.1           01-12-3b-44-53-d6     dynamic';
-        $arp_output .= '192.168.5.3           a0-4b-c2-de-93-23     dynamic';
+        $arp_output = 'Internet Address      Physical Address      Type'.PHP_EOL;
         foreach($this->response_component as $response_component){
-            $arp_output .= $response_component['ip'].'           '.$response_component['mac'].'    dynamic';
+            $arp_output .= $response_component['ip'].'           ';
+            $arp_output .= strtolower($this->normalise_mac_address($response_component['mac'], self::PHYSICAL_ADDRESS_SEPARATOR_DASH));
+            $arp_output .= '    dynamic'.PHP_EOL;
         }
         return $arp_output;
     }
@@ -77,12 +84,11 @@ class NetworkScanner extends NetScan {
      * @return string
      */
     private function get_example_unix_arp_output(){
-        $arp_output = '';
-        $arp_output .= 'Address                  HWtype  HWaddress           Flags Mask            Iface';
-        $arp_output .= '192.168.5.3              ether   a0:4b:c2:de:93:23   C                     eth0';
-        $arp_output .= '192.168.5.1              ether   01:12:3b:44:53:d6   C                     eth0';
+        $arp_output = 'Address                  HWtype  HWaddress           Flags Mask            Iface'.PHP_EOL;
         foreach($this->response_component as $response_component){
-            $arp_output .= $response_component['ip'].'              ether   '.$response_component['mac'].'   C                     eth0';
+            $arp_output .= $response_component['ip'].'              ether   ';
+            $arp_output .= strtolower($this->normalise_mac_address($response_component['mac'], self::PHYSICAL_ADDRESS_SEPARATOR_COLON));
+            $arp_output .= '   C                     eth0'.PHP_EOL;
         }
         return $arp_output;
     }

--- a/tests/NetworkScannerTest.php
+++ b/tests/NetworkScannerTest.php
@@ -2,10 +2,11 @@
 
 namespace jdenoc\NetworkScanner\Tests;
 
+use PHPUnit_Framework_TestCase as PhpUnitTestCase;
 use Faker;
 use jdenoc\NetworkScanner\Tests\NetworkScanner as TNS;
 
-class NetworkScannerTest extends \PHPUnit_Framework_TestCase {
+class NetworkScannerTest extends PhpUnitTestCase {
 
     /**
      * @var Faker\Generator


### PR DESCRIPTION
- Removed hard-coding of `arp` output from `Tests\NetworkScanner`. Instead we'll use the class methods to add IP and physical (mac) address' for the arp output.
- Simplified the normalisation process of a physical (mac) address.
- `NetworkScanner->is_physical_address_on_network` now searches `arp` output using `stripos`. This saves us having to adjust the case of the physical (mac) address and the potential of a mixed case response from `arp`.
- Modified `.gitattributes` so that the test helper class can be included via composer.

